### PR TITLE
Support netmask in ip_pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ rvm:
   - 1.9.2
   - 1.9.3-p0
 notifications:
-  email:
-    - udzura@udzura.jp
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@
 rvm:
   - 1.8.7
   - 1.9.2
-  - 1.9.3-p0
+  - 1.9.3-p551
 notifications:
   email: false

--- a/lib/rack/block/dsl/matchers.rb
+++ b/lib/rack/block/dsl/matchers.rb
@@ -1,4 +1,5 @@
 require 'rack/block/dsl/builtin_bot_pattern'
+require 'rack/block/ipaddr/monkeypatch'
 module Rack::Block::DSL
   module Matchers
     def bot_access(&block)
@@ -42,6 +43,8 @@ module Rack::Block::DSL
       when /^(\d+)(\.\d+){0,2}\.?$/
         ip_pattern = ip_pattern.sub(/\.$/, '')
         Regexp.compile("^" + ip_pattern.gsub('.', '\\.') + '(\\.\\d+)+' + "$")
+      when /^\d+\.\d+\.\d+\.\d+\/\d+$/
+        IPAddr.new(ip_pattern)
       else
         raise ArgumentError, 'passed invalid IP string'
       end

--- a/lib/rack/block/ipaddr/monkeypatch.rb
+++ b/lib/rack/block/ipaddr/monkeypatch.rb
@@ -1,0 +1,7 @@
+require 'ipaddr'
+
+class IPAddr
+  def =~(target)
+    include?(target)
+  end
+end

--- a/spec/integrations/ip_blocking_spec.rb
+++ b/spec/integrations/ip_blocking_spec.rb
@@ -50,25 +50,32 @@ describe "Blocking by IP" do
     end
   end
 
-  it 'blocks accesses from a specific IP pattern(with a netmask)' do
-    pending "Not yet implemented, netmask expressions to Regexp or some other matching methods..."
-    mock_app {
-      use Rack::Block do
-        ip_pattern '10.20.30.0/24' do
-          halt 404
+  describe 'blocks accesses from a specific IP pattern(with a netmask)' do
+    before do
+      mock_app {
+        use Rack::Block do
+          ip_pattern '10.20.30.0/24' do
+            halt 404
+          end
         end
-      end
-      run DEFAULT_APP
-    }
-      
-    ['/', '/any', '/path/blocked'].each do |path|
-      get path
-      last_response.should be_not_found
+        run DEFAULT_APP
+      }
     end
 
-    ['/', '/any', '/path/blocked'].each do |path|
-      get path
-      last_response.should be_not_found
+    it 'blocks 10.20.30.40 when supplied with 10.20.30.0/24' do
+      Rack::Request.any_instance.stubs(:ip).returns('10.20.30.40')
+      ['/', '/any', '/path/blocked'].each do |path|
+        get path
+        last_response.should be_not_found
+      end
+    end
+
+    it 'does not block 10.20.31.0 when supplied with 10.20.30.0/24' do
+      Rack::Request.any_instance.stubs(:ip).returns('10.20.31.0')
+      ['/', '/any', '/path/blocked'].each do |path|
+        get path
+        last_response.should be_ok
+      end
     end
   end
 end


### PR DESCRIPTION
When passed IP address to `ip_pattern` with cidr expression, evaluate is client IP included cidr range with monkey-patched `IPAddr` instance using `include?` method as `=~`.

I want to rebase and merge it to after of merge #3  .

(If so I remove 88e8a3f and 83c3aec)